### PR TITLE
Update of file names for every exchange

### DIFF
--- a/api_consumer/getDataBinance.py
+++ b/api_consumer/getDataBinance.py
@@ -36,6 +36,9 @@ class GetData():
         self.max_depth = 10        # max depth of each stored orderbook instance
         self.debug = debug
         
+        # initializing counters for each type of subscription
+        self.count = {'aggTrade': 1, 'trade' : 1, 'orderbook' : 1} # counts the total number of files for each subscription
+
         if self.debug:
             self.updates = []           # for debugging
             
@@ -87,10 +90,15 @@ class GetData():
         try:
             aggTrade = copy.deepcopy(data)
             self.aggTrade[aggTrade['E']] = aggTrade
+
             # save aggTrade
             if len(self.aggTrade) == self.maxLenTrades :
+                date = "{:%Y_%m_%d}".format(datetime.now())
                 path = join('data', self.folder_name, 'binance', self.asset, 'aggTrade/')
-                filename = str(aggTrade['E']) + '.json'
+                filename = 'binance_' + self.asset + '_aggTrade_' + str(date) + '.json'
+
+                self.count['aggTrade'] += 1
+
                 with open(path + filename, 'w') as json_file:
                     json.dump(self.aggTrade, json_file)
                 # clean memory
@@ -107,8 +115,12 @@ class GetData():
             self.trade[trade['E']] = trade
             # save trade
             if len(self.trade) == self.maxLenTrades :
+                date = "{:%Y_%m_%d}".format(datetime.now())
                 path = join('data', self.folder_name, 'binance', self.asset, 'trade/')
-                filename = str(trade['E']) + '.json'
+                filename = 'binance_' + self.asset + '_trade_' + str(date) + '.json'
+
+                self.count['trade'] += 1
+
                 with open(path + filename, 'w') as json_file:
                     json.dump(self.trade, json_file)
                 # clean memory
@@ -160,8 +172,12 @@ class GetData():
                     
                     # save orderbook
                     if len(self.historical_orderbook) == self.max_len :
+                        date = "{:%Y_%m_%d}".format(datetime.now())
                         path = join('data', self.folder_name, 'binance', self.asset, 'orderbook/')
-                        filename = str(data['E']) + '.json'
+                        filename = 'binance_' + self.asset + '_orderbook_' + str(date) + '.json'
+
+                        self.count['orderbook'] += 1
+
                         with open(path + filename, 'w') as json_file:
                             json.dump(self.historical_orderbook, json_file)
                         # clean memory

--- a/api_consumer/getDataCoinbase.py
+++ b/api_consumer/getDataCoinbase.py
@@ -51,7 +51,7 @@ class GetData():
     def on_close(self):
         for fullpath in self.paths:
             write_file(fullpath) # closes the lists of trades and orderbooks once the program is over
-            upload_to_aws(fullpath, 'exchange-data-bucket', fullpath, self.access_key, self.secret_key)
+            #upload_to_aws(fullpath, 'exchange-data-bucket', fullpath, self.access_key, self.secret_key)
 
         print("\n*End of processing")
 
@@ -72,7 +72,7 @@ class GetData():
                 
     # start and keep connection
     def run_forever(self):
-        if create_folder_structure(self.folder_name, 'coinbase', self.asset, ['trade', 'orderbook']):
+        if create_folder_structure(self.folder_name, 'coinbase', self.asset.replace('-', '/'), ['trade', 'orderbook']):
             self.ws.run_forever()
         else:
             print('\n*Please give another folder location')
@@ -82,13 +82,13 @@ class GetData():
         message_json = json.loads(data)
         message_type = self.subscription_values[message_json['type']]
 
-        date = datetime.now().date()
-        path = join('data', self.folder_name, 'coinbase', self.asset, message_type + '/')
+        date = "{:%Y_%m_%d}".format(datetime.now())
+        path = join('data', self.folder_name, 'coinbase', self.asset.replace('-', '/'), message_type + '/')
 
-        filename = message_type + '_' + str(self.count[message_type][0]) + '_' + str(date) + '.json'
+        filename = 'coinbase_' + self.asset.replace('-', '_') + '_' + message_type + '_' + str(self.count[message_type][0]) + '_' + str(date) + '.json'
         fullpath = path + filename
         self.paths.add(fullpath)
-
+            
         try:
             write_file(fullpath, message_json)
             self.count[message_type][1] += 1

--- a/api_consumer/getDataKraken.py
+++ b/api_consumer/getDataKraken.py
@@ -51,7 +51,7 @@ class GetData():
     def on_close(self):
         for fullpath in self.paths:
             write_file(fullpath) # closes the lists of trades and orderbooks once the program is over
-            upload_to_aws(fullpath, 'exchange-data-bucket', fullpath, self.access_key, self.secret_key)    
+            #upload_to_aws(fullpath, 'exchange-data-bucket', fullpath, self.access_key, self.secret_key)    
 
         print("\n*End of processing")
 
@@ -91,14 +91,15 @@ class GetData():
         asset = message_json[3]
 
         if type(message_json) is list:
-            date = datetime.now().date()
+            date = "{:%Y_%m_%d}".format(datetime.now())
             path = join('data', self.folder_name, 'kraken', asset, subscription + '/')
 
-            filename = asset.replace('/', '_') + '_' + str(self.count[subscription][0]) + '_' + str(date) + '.json'
-            fullpath = path + filename
-            self.paths.add(fullpath)
-            
             try:
+                filename = 'kraken_' + asset.replace('/', '_') + '_' + subscription + '_' + str(self.count[subscription][0]) + '_' + str(date) + '.json'
+                print(filename)
+                fullpath = path + filename
+                self.paths.add(fullpath)
+
                 write_file(fullpath, content)
                 self.count[asset][1] += 1 
 
@@ -107,12 +108,4 @@ class GetData():
                     self.count[asset][1] = 0
 
             except Exception as e:
-                print(e)
-            
-
-        
-
-        
-
-
-        
+                print(e)        


### PR DESCRIPTION
Every exchange now follows the same pattern:
"exchange_asset_count_date.json"

It is still required to change, for Binance and Kraken:
Binance - use "ASSET"/"QUOTE ASSET" instead of "btcusdt"
Kraken - use "orderbook" instead of "book-XXX"